### PR TITLE
fixes for initializing GPU pixel array

### DIFF
--- a/src/cameras/SlowLightIntensityCamera.jl
+++ b/src/cameras/SlowLightIntensityCamera.jl
@@ -84,7 +84,7 @@ struct SlowLightIntensityScreen{T, A <:AbstractMatrix} <: AbstractScreen
 
         _generate_screen!(backend)(screen, met, αmin, αmax, βmin, βmax, θo, res, ndrange = (res, res))
         
-        new{T, A}((αmin, αmax), (βmin, βmax), screen)
+        new{T, typeof(screen)}((αmin, αmax), (βmin, βmax), screen)
     end
 end
 
@@ -101,7 +101,8 @@ struct SlowLightIntensityCamera{T, A} <: AbstractCamera
     "Observer screen_coordinate"
     screen_coordinate::NTuple{2, T}
     function SlowLightIntensityCamera(met::Kerr{T}, θo, αmin, αmax, βmin, βmax, res; A=Matrix) where {T}
-        new{T, A}(met, SlowLightIntensityScreen(met, αmin, αmax, βmin, βmax, θo, res), (T(Inf), θo))
+        screen = SlowLightIntensityScreen(met, αmin, αmax, βmin, βmax, θo, res; A)
+        new{T,typeof(screen.pixels)}(met, screen, (T(Inf), θo))
     end
 end
 

--- a/src/schemes/schemes.jl
+++ b/src/schemes/schemes.jl
@@ -30,7 +30,7 @@ function render_cpu_threaded!(store, camera::AbstractCamera, scene::Scene)
     @assert size(store) == size(camera.screen.pixels)
     mapreduce(
         mesh -> begin
-            @Threads.threads for I in CartesianIndices(camera.screen.pixels)
+            Threads.@threads for I in CartesianIndices(camera.screen.pixels)
                 store[I] = mesh.material(camera.screen.pixels[I], mesh.geometry)
             end
             store


### PR DESCRIPTION
Currently abstract type parameters are being passed to the constructors which lead to confusing errors unless a full explicit type signature is given.  This allows one to pass, for example `CuMatrix` and wind up with concrete typed objects.