### PR TITLE
Added a bunch of inlines

### DIFF
--- a/src/geometries/geometry_types.jl
+++ b/src/geometries/geometry_types.jl
@@ -44,7 +44,7 @@ struct ConeGeometry{T,A} <: AbstractGeometry
         new{T,A}(opening_angle, attributes)
 end
 
-function _raytrace(
+@inline function _raytrace(
     observation,
     pix::AbstractPixel,
     mesh::Mesh{<:ConeGeometry{T,A},<:AbstractMaterial};
@@ -55,29 +55,50 @@ function _raytrace(
     θs = geometry.opening_angle
     subimgs = material.subimgs
 
-    isindir = false
-    for _ = 1:2 # Looping over isindir this way is needed to get Metal to work
-        isindir ⊻= true
-        for n in subimgs
-            #νθ = cos(θs) < abs(cos(θo)) ? (θo > θs) ⊻ (n % 2 == 1) : !isindir
-            intersection, issuccess = if isFastLight(material)
-                if isAxisymmetric(material)
-                    rs, νr, νθ, _, issuccess = emission_radius(pix, θs, isindir, n)
-                    Intersection(zero(rs), rs, θs, zero(rs), νr, νθ), issuccess
-                else
-                    rs, ϕs, νr, νθ, issuccess =
-                        emission_coordinates_fast_light(pix, θs, isindir, n)
-                    Intersection(zero(rs), rs, θs, ϕs, νr, νθ), issuccess
-                end
+    isindir = true
+    for n in subimgs
+        #νθ = cos(θs) < abs(cos(θo)) ? (θo > θs) ⊻ (n % 2 == 1) : !isindir
+        intersection, issuccess = if isFastLight(material)
+            if isAxisymmetric(material)
+                rs, νr, νθ, _, issuccess = @inline emission_radius(pix, θs, isindir, n)
+                Intersection(zero(rs), rs, θs, zero(rs), νr, νθ), issuccess
             else
-                ts, rs, ϕs, νr, νθ, issuccess = emission_coordinates(pix, θs, isindir, n)
-                Intersection(ts, rs, θs, ϕs, νr, νθ), issuccess
+                rs, ϕs, νr, νθ, issuccess =
+                    @inline emission_coordinates_fast_light(pix, θs, isindir, n)
+                Intersection(zero(rs), rs, θs, ϕs, νr, νθ), issuccess
             end
-            if issuccess && (horizon(metric(pix)) < rs < T(Inf))
-                observation += material(pix, intersection)
-            end
+        else
+            ts, rs, ϕs, νr, νθ, issuccess = @inline emission_coordinates(pix, θs, isindir, n)
+            Intersection(ts, rs, θs, ϕs, νr, νθ), issuccess
+        end
+        
+        if issuccess && (horizon(metric(pix)) < rs < T(Inf))
+            observation += @inline(material(pix, intersection))
         end
     end
+
+    isindir = false
+    for n in subimgs
+        #νθ = cos(θs) < abs(cos(θo)) ? (θo > θs) ⊻ (n % 2 == 1) : !isindir
+        intersection, issuccess = if isFastLight(material)
+            if isAxisymmetric(material)
+                rs, νr, νθ, _, issuccess = @inline emission_radius(pix, θs, isindir, n)
+                Intersection(zero(rs), rs, θs, zero(rs), νr, νθ), issuccess
+            else
+                rs, ϕs, νr, νθ, issuccess =
+                    @inline emission_coordinates_fast_light(pix, θs, isindir, n)
+                Intersection(zero(rs), rs, θs, ϕs, νr, νθ), issuccess
+            end
+        else
+            ts, rs, ϕs, νr, νθ, issuccess = @inline emission_coordinates(pix, θs, isindir, n)
+            Intersection(ts, rs, θs, ϕs, νr, νθ), issuccess
+        end
+
+        if issuccess && (horizon(metric(pix)) < rs < T(Inf))
+            observation += @inline(material(pix, intersection))
+        end
+    end
+
     return observation
 end
 

--- a/src/geometries/level_set_geometry.jl
+++ b/src/geometries/level_set_geometry.jl
@@ -47,7 +47,7 @@ function _raytrace(
     return observation
 end
 
-function line_intersection(
+@inline function line_intersection(
     origin::NTuple{3,T},
     line_point_2,
     geometry::AbstractLevelSetGeometry{T},

--- a/src/materials/ElectronSynchrotronPowerLawIntensity.jl
+++ b/src/materials/ElectronSynchrotronPowerLawIntensity.jl
@@ -1,7 +1,7 @@
 """
 Calculates the intensity of a photon emitted from a fluid particle with momentum f_u and observed by an asymptotic observer.
 """
-function synchrotronIntensity(
+@inline function synchrotronIntensity(
     metric::Kerr{T},
     α,
     β,

--- a/src/materials/ElectronSynchrotronPowerLawPolarization.jl
+++ b/src/materials/ElectronSynchrotronPowerLawPolarization.jl
@@ -1,7 +1,7 @@
 """
 Returns the screen polarization associated with a killing spinor κ as seen seen by an asymptotic observer.
 """
-function screen_polarization(metric::Kerr{T}, κ::Complex, θ, α, β) where {T}# Eq 31 10.1103/PhysRevD.104.044060
+@inline function screen_polarization(metric::Kerr{T}, κ::Complex, θ, α, β) where {T}# Eq 31 10.1103/PhysRevD.104.044060
     a = metric.spin
     κ1 = real(κ)
     κ2 = imag(κ)
@@ -19,7 +19,7 @@ evpa(fα, fβ) = atan(-fα, fβ)
 """
 Calculates the polarization of a photon emitted from a fluid particle with momentum f_u and observed by an asymptotic observer.
 """
-function synchrotronPolarization(
+@inline function synchrotronPolarization(
     metric::Kerr{T},
     α,
     β,
@@ -172,7 +172,7 @@ end
 """
     Functor for the ElectronSynchrotronPowerLawPolarization material
 """
-function (linpol::ElectronSynchrotronPowerLawPolarization{N,T})(
+@inline function (linpol::ElectronSynchrotronPowerLawPolarization{N,T})(
     pix::AbstractPixel,
     intersection,
 ) where {N,T}

--- a/src/metrics/Kerr/Kerr.jl
+++ b/src/metrics/Kerr/Kerr.jl
@@ -59,7 +59,7 @@ end
 """
 Inverse Kerr metric in Boyer Lindquist (BL) coordinates.
 """
-function metric_uu(metric::Kerr{T}, r, θ) where {T}
+@inline function metric_uu(metric::Kerr{T}, r, θ) where {T}
     Δt = Δ(metric, r)
     Ξt = Ξ(metric, r, θ; Δ = Δt)
     Σt = Σ(metric, r, θ)
@@ -82,7 +82,7 @@ Inverse Kerr metric in Boyer Lindquist (BL) coordinates.
 - `metric` : Kerr metric
 - `coordinates` : Coordinates (t, r, θ, ϕ)
 """
-function metric_uu(metric::Kerr{T}, coordinates) where {T}
+@inline function metric_uu(metric::Kerr{T}, coordinates) where {T}
     _, r, θ, _ = coordinates
     metric_uu(metric, r, θ)
 end
@@ -90,7 +90,7 @@ end
 """
 Kerr metric in Boyer Lindquist (BL) coordinates.
 """
-function metric_dd(metric::Kerr{T}, r, θ) where {T}
+@inline function metric_dd(metric::Kerr{T}, r, θ) where {T}
     Δt = Δ(metric, r)
     Ξt = Ξ(metric, r, θ; Δ = Δt)
     Σt = Σ(metric, r, θ)
@@ -115,7 +115,7 @@ Kerr metric in Boyer Lindquist (BL) coordinates.
 - `metric` : Kerr metric
 - `coordinates` : Coordinates (t, r, θ, ϕ)
 """
-function metric_dd(metric::Kerr{T}, coordinates) where {T}
+@inline function metric_dd(metric::Kerr{T}, coordinates) where {T}
     _, r, θ, _ = coordinates
     return metric_dd(metric, r, θ)
 end

--- a/src/metrics/Kerr/emission_coordinates.jl
+++ b/src/metrics/Kerr/emission_coordinates.jl
@@ -29,19 +29,19 @@ Returns 0 if the emission coordinates do not exist for that screen coordinate.
 - `isindir` : Is emission to observer direct or indirect
 - `n` : Image index
 """
-function emission_radius(
+@inline function emission_radius(
     pix::Krang.AbstractPixel,
     θs::T,
     isindir,
     n,
-)::Tuple{T,Bool,Bool,Int,Bool} where {T}
+) where {T}
     α, β = screen_coordinate(pix)
     θo = inclination(pix)
-    met = metric(pix)
+    met = @inline metric(pix)
     isincone = θo ≤ θs ≤ (π - θo) || (π - θo) ≤ θs ≤ θo
     if !isincone
-        αmin = αboundary(met, θs)
-        βbound = (abs(α) >= (αmin + eps(T)) ? βboundary(met, α, θo, θs) : zero(T))
+        αmin = @inline αboundary(met, θs)
+        βbound = (abs(α) >= (αmin + eps(T)) ? @inline(βboundary(met, α, θo, θs)) : zero(T))
         ((abs(β) + eps(T)) < βbound) && return zero(T), true, true, 0, false
     end
 
@@ -54,7 +54,7 @@ function emission_radius(
         νθ = (θo > θs) ⊻ (n % 2 == 1)
     end
 
-    ans, νr, numreals, issuccess = emission_radius(pix, τ)
+    ans, νr, numreals, issuccess = @inline emission_radius(pix, τ)
     return ans, νr, νθ, numreals, issuccess
 end
 
@@ -67,7 +67,7 @@ Returns 0 if the emission coordinates do not exist for that screen coordinate.
 -`pix` : Pixel information
 - `τ` : Mino time
 """
-function emission_radius(pix::AbstractPixel, τ::T)::Tuple{T,Bool,Int,Bool} where {T}
+@inline function emission_radius(pix::AbstractPixel, τ::T)::Tuple{T,Bool,Int,Bool} where {T}
     met = metric(pix)
     a = met.spin
     ans = zero(T)
@@ -96,7 +96,7 @@ Emission inclination for point originating at inclination rs whose nth order ima
 - `rs` : Emission radius
 - `νr` : Sign of radial velocity direction at emission. This is always positive for case 3 and case 4 geodesics.
 """
-function emission_inclination(pix::AbstractPixel, rs, νr)
+@inline function emission_inclination(pix::AbstractPixel, rs, νr)
     return emission_inclination(pix, Ir(pix, νr, rs))
 end
 
@@ -108,7 +108,7 @@ Emission inclination for point at Mino time τ whose image appears at screen coo
 - `pix` : Pixel information
 - `τ` : Mino Time
 """
-function emission_inclination(pix::AbstractPixel, τ)
+@inline function emission_inclination(pix::AbstractPixel, τ)
     met = metric(pix)
     θo = inclination(pix)
     α, β = pix.screen_coordinate
@@ -127,7 +127,7 @@ Emission azimuth for point at Mino time τ whose image appears at screen coordin
 - `τ` : Mino Time
 - `νr` : Sign of radial velocity direction at emission. This is always positive for case 3 and case 4 geodesics.
 """
-function emission_azimuth(pix::AbstractPixel, θs, rs, τ::T, νr, isindir, n) where {T}
+@inline function emission_azimuth(pix::AbstractPixel, θs, rs, τ::T, νr, isindir, n) where {T}
     met = metric(pix)
     θo = inclination(pix)
 
@@ -136,7 +136,7 @@ function emission_azimuth(pix::AbstractPixel, θs, rs, τ::T, νr, isindir, n) w
     Iϕ = Krang.Iϕ(pix, rs, τ, νr)
     (isnan(Iϕ) || !isfinite(Iϕ)) && return Iϕ
 
-    Gϕtemp, _, _, _ = Gϕ(pix, θs, isindir, n)
+    Gϕtemp, _, _, _ = @inline Gϕ(pix, θs, isindir, n)
     (isnan(Gϕtemp) || !isfinite(Gϕtemp)) && return Iϕ
 
     return -(Iϕ + λtemp * Gϕtemp + T(π / 2))
@@ -153,7 +153,7 @@ coordinate (`α`, `β`) for an observer located at inclination θo.
 - `isindir` : Whether emission to observer is direct or indirect
 - `n` : Image index
 """
-function emission_coordinates_fast_light(pix::AbstractPixel, θs::T, isindir, n) where {T}
+@inline function emission_coordinates_fast_light(pix::AbstractPixel, θs::T, isindir, n) where {T}
     # NB: I do not return θs since it is already known, and returning it might encourage bad coding errors
     α, β = screen_coordinate(pix)
     θo = inclination(pix)
@@ -165,7 +165,7 @@ function emission_coordinates_fast_light(pix::AbstractPixel, θs::T, isindir, n)
         ((abs(β) + eps(T)) < βbound) && return zero(T), zero(T), false, false, false
     end
 
-    τ, _, _, _, _, issuccess = Gθ(pix, θs, isindir, n)
+    τ, _, _, _, _, issuccess = @inline Gθ(pix, θs, isindir, n)
     issuccess || return (zero(T), zero(T), false, false, false)
 
     # is θ̇s increasing or decreasing?
@@ -177,7 +177,7 @@ function emission_coordinates_fast_light(pix::AbstractPixel, θs::T, isindir, n)
     rs, νr, _, issuccess = emission_radius(pix, τ)
     issuccess || return (zero(T), zero(T), false, false, false)
 
-    ϕs = emission_azimuth(pix, θs, rs, τ, νr, isindir, n)
+    ϕs = @inline emission_azimuth(pix, θs, rs, τ, νr, isindir, n)
 
     return rs, ϕs, νr, νθ, issuccess
 end
@@ -190,17 +190,17 @@ Ray trace a point that appears at the screen coordinate (`α`, `β`) for an obse
 - `pix` : Pixel information
 - `τ` : Mino Time
 """
-function emission_coordinates_fast_light(pix::AbstractPixel, τ::T) where {T}
-    α, β = screen_coordinate(pix)
+@inline function emission_coordinates_fast_light(pix::AbstractPixel, τ::T) where {T}
+    α, β = @inline screen_coordinate(pix)
     met = metric(pix)
     θo = inclination(pix)
 
-    θs, τs, _, _, n, isindir = emission_inclination(pix, τ)
+    θs, τs, _, _, n, isindir = @inline emission_inclination(pix, τ)
     νθ = τs > 0
 
     if cos(θs) > abs(cos(θo))
-        αmin = αboundary(met, θs)
-        βbound = (abs(α) >= (αmin + eps(T)) ? βboundary(met, α, θo, θs) : zero(T))
+        αmin = @inline αboundary(met, θs)
+        βbound = (abs(α) >= (αmin + eps(T)) ? @inline(βboundary(met, α, θo, θs)) : zero(T))
 
         if (abs(β) + eps(T)) < βbound
             return zero(T), zero(T), zero(T), true, true, false
@@ -210,16 +210,16 @@ function emission_coordinates_fast_light(pix::AbstractPixel, τ::T) where {T}
     a = met.spin
 
     λtemp = λ(met, α, θo)
-    rs, νr, _, issuccess = emission_radius(pix, τ)
+    rs, νr, _, issuccess = @inline emission_radius(pix, τ)
     issuccess || return zero(T), zero(T), zero(T), true, true, false
-    _, _, _, Ip, Im = radial_integrals(pix, rs, τ, νr)
+    _, _, _, Ip, Im = @inline radial_integrals(pix, rs, τ, νr)
 
     rp = one(T) + √(one(T) - a^2)
     rm = one(T) - √(one(T) - a^2)
 
     Iϕ = 2a / (rp - rm) * ((rp - a * λtemp / 2) * Ip - (rm - a * λtemp / 2) * Im)
 
-    Gϕtemp, _, _, _, _ = Gϕ(pix, θs, isindir, n)
+    Gϕtemp, _, _, _, _ = @inline Gϕ(pix, θs, isindir, n)
 
     emission_azimuth = -(Iϕ + λtemp * Gϕtemp + T(π / 2))
 
@@ -239,25 +239,25 @@ coordinate (`α`, `β`) for an observer located at inclination θo.
 - `isindir` : Whether emission to observer is direct or indirect
 - `n` : Image index
 """
-function emission_coordinates(pix::AbstractPixel, θs::T, isindir, n) where {T}
+@inline function emission_coordinates(pix::AbstractPixel, θs::T, isindir, n) where {T}
     α, β = pix.screen_coordinate
     met = metric(pix)
     θo = inclination(pix)
     cosθs = cos(θs)
     cosθo = cos(θo)
     if cos(θs) > abs(cosθo)
-        αmin = αboundary(met, θs)
-        βbound = (abs(α) >= (αmin + eps(T)) ? βboundary(met, α, θo, θs) : zero(T))
+        αmin = @inline αboundary(met, θs)
+        βbound = (abs(α) >= (αmin + eps(T)) ? @inline(βboundary(met, α, θo, θs)) : zero(T))
 
         if (abs(β) + eps(T)) < βbound
             return zero(T), zero(T), zero(T), false, false, false
         end
     end
 
-    τ, _, _, _, _, issuccess = Gθ(pix, θs, isindir, n)
+    τ, _, _, _, _, issuccess = @inline Gθ(pix, θs, isindir, n)
     issuccess || return zero(T), zero(T), zero(T), false, false, false
 
-    rs, νr, _, issuccess = emission_radius(pix, τ)
+    rs, νr, _, issuccess = @inline emission_radius(pix, τ)
     issuccess || return zero(T), zero(T), zero(T), false, false, false
 
     a = met.spin
@@ -273,7 +273,7 @@ function emission_coordinates(pix::AbstractPixel, θs::T, isindir, n) where {T}
         return zero(T), zero(T), zero(T), false, false, false
     end
 
-    I0, I1, I2, Ip, Im = radial_integrals(pix, rs, τ, νr)
+    I0, I1, I2, Ip, Im = @inline radial_integrals(pix, rs, τ, νr)
 
     rp = one(T) + √(one(T) - a^2)
     rm = one(T) - √(one(T) - a^2)
@@ -285,8 +285,8 @@ function emission_coordinates(pix::AbstractPixel, θs::T, isindir, n) where {T}
         I2
     Iϕ = 2a / (rp - rm) * ((rp - a * λtemp / 2) * Ip - (rm - a * λtemp / 2) * Im)
 
-    Gϕtemp, _, _, _, _ = Gϕ(pix, θs, isindir, n)
-    Gttemp, _, _, _, _ = Gt(pix, θs, isindir, n)
+    Gϕtemp, _, _, _, _ = @inline Gϕ(pix, θs, isindir, n)
+    Gttemp, _, _, _, _ = @inline Gt(pix, θs, isindir, n)
 
     emission_azimuth = -(Iϕ + λtemp * Gϕtemp + T(π / 2))
     emission_time_regularized = (zero(T) + It + a^2 * Gttemp)
@@ -305,17 +305,17 @@ Ray trace a point that appears at the screen coordinate (`α`, `β`) for an obse
 - `pix` : Pixel information
 - `τ` : Mino Time
 """
-function emission_coordinates(pix::AbstractPixel, τ::T) where {T}
+@inline function emission_coordinates(pix::AbstractPixel, τ::T) where {T}
     α, β = screen_coordinate(pix)
     met = metric(pix)
     θo = inclination(pix)
 
-    θs, τs, _, _, n, isindir = emission_inclination(pix, τ)
+    θs, τs, _, _, n, isindir = @inline emission_inclination(pix, τ)
     νθ = τs > 0
 
     if cos(θs) > abs(cos(θo))
-        αmin = αboundary(met, θs)
-        βbound = (abs(α) >= (αmin + eps(T)) ? βboundary(met, α, θo, θs) : zero(T))
+        αmin = @inline αboundary(met, θs)
+        βbound = (abs(α) >= (αmin + eps(T)) ? @inline(βboundary(met, α, θo, θs)) : zero(T))
 
         if (abs(β) + eps(T)) < βbound
             return zero(T), zero(T), zero(T), zero(T), true, true, false
@@ -325,9 +325,9 @@ function emission_coordinates(pix::AbstractPixel, τ::T) where {T}
     a = met.spin
 
     λtemp = λ(met, α, θo)
-    rs, νr, _, issuccess = emission_radius(pix, τ)
+    rs, νr, _, issuccess = @inline emission_radius(pix, τ)
     issuccess || return zero(T), zero(T), zero(T), zero(T), true, true, false
-    I0, I1, I2, Ip, Im = radial_integrals(pix, rs, τ, νr)
+    I0, I1, I2, Ip, Im = @inline radial_integrals(pix, rs, τ, νr)
 
     rp = one(T) + √(one(T) - a^2)
     rm = one(T) - √(one(T) - a^2)
@@ -339,8 +339,8 @@ function emission_coordinates(pix::AbstractPixel, τ::T) where {T}
         I2
     Iϕ = 2a / (rp - rm) * ((rp - a * λtemp / 2) * Ip - (rm - a * λtemp / 2) * Im)
 
-    Gϕtemp, _, _, _, _ = Gϕ(pix, θs, isindir, n)
-    Gttemp, _, _, _, _ = Gt(pix, θs, isindir, n)
+    Gϕtemp, _, _, _, _ = @inline Gϕ(pix, θs, isindir, n)
+    Gttemp, _, _, _, _ = @inline Gt(pix, θs, isindir, n)
 
     emission_azimuth = -(Iϕ + λtemp * Gϕtemp + T(π / 2))
     emission_time_regularized = (It + a^2 * Gttemp)
@@ -353,7 +353,7 @@ function θs(metric::Kerr{T}, α, β, θo, τ) where {T}
     return _θs(metric, sign(β), θo, η(metric, α, β, θo), λ(metric, α, θo), τ)
 end
 
-function _θs(metric::Kerr{T}, signβ, θo, η, λ, τ) where {T}
+@inline function _θs(metric::Kerr{T}, signβ, θo, η, λ, τ) where {T}
     a = metric.spin
     Ghat_2, isvortical = zero(T), η < zero(T)
 

--- a/src/metrics/Kerr/misc.jl
+++ b/src/metrics/Kerr/misc.jl
@@ -184,7 +184,7 @@ Defines a horizontal boundary on the assymptotic observer's screen that emission
 - `metric`: Kerr metric
 - `θs`  : Emission Inclination
 """
-function αboundary(metric::Kerr, θs)
+@inline function αboundary(metric::Kerr, θs)
     return metric.spin * sin(θs)
 end
 
@@ -198,7 +198,7 @@ Defines a vertical boundary on the assymptotic observer's screen that emission t
 - `θo`  : Observer inclination
 - `θs`  : Emission Inclination
 """
-function βboundary(metric::Kerr{T}, α, θo, θs) where {T}
+@inline function βboundary(metric::Kerr{T}, α, θo, θs) where {T}
     a = metric.spin
     cosθs2 = cos(θs)^2
     return √max(
@@ -251,7 +251,7 @@ Returns roots of \$r^4 + (a^2-η-λ^2)r^2 + 2(η+(a-λ)^2)r - a^2η\$
 - `η`  : Reduced Carter constant
 - `λ`  : Reduced azimuthal angular momentum
 """
-function get_radial_roots(metric::Kerr{T}, η, λ) where {T}
+@inline function get_radial_roots(metric::Kerr{T}, η, λ) where {T}
     a = metric.spin
 
     a2 = a * a
@@ -293,7 +293,7 @@ function get_radial_roots(metric::Kerr{T}, η, λ) where {T}
     return roots
 end
 
-function _get_root_diffs(r1::T, r2::T, r3::T, r4::T) where {T}
+@inline function _get_root_diffs(r1::T, r2::T, r3::T, r4::T) where {T}
     return r2 - r1, r3 - r1, r3 - r2, r4 - r1, r4 - r2, r4 - r3
 end
 
@@ -321,10 +321,10 @@ See [`r_potential(x)`](@ref) for an implementation of \$\\mathcal{R}(r)\$.
 """
 function Ir_inf(metric::Kerr{T}, roots) where {T}
     #root_diffs = _get_root_diffs(roots...)
-    numreals = sum(_isreal2.(roots))
+    numreals = sum(map(_isreal2, roots))
 
     if numreals == 4 #case 2
-        return Ir_inf_case1_and_2(metric, real.(roots))
+        return Ir_inf_case1_and_2(metric, map(real, roots))
     elseif numreals == 2 #case3
         return Ir_inf_case3(metric, roots)
     else #case 4
@@ -954,7 +954,7 @@ See [`r_potential(x)`](@ref) for an implementation of \$\\mathcal{R}(r)\$.
 - `λ`  : Reduced azimuthal angular momentum
 - `νr` : Radial emission direction (Only necessary for case 1&2 geodesics)
 """
-function It_w_I0_terms(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr) where {T}
+@inline function It_w_I0_terms(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr) where {T}
     numreals = sum(_isreal2.(roots))
 
     if numreals == 4 #case 2
@@ -966,7 +966,7 @@ function It_w_I0_terms(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr) where
     return It_w_I0_terms_case4(metric, rs, τ, roots, λ)
 end
 
-function It_w_I0_terms_case2(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr) where {T}
+@inline function It_w_I0_terms_case2(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr) where {T}
     r1, r2, r3, r4 = roots
     _, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
     r43 = r4 - r3
@@ -1030,7 +1030,7 @@ function It_w_I0_terms_case2(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ, νr)
     )
 end
 
-function It_w_I0_terms_case3(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) where {T}
+@inline function It_w_I0_terms_case3(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) where {T}
     r1, r2, _, _ = roots
     r21, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
     r21 = real(r21)
@@ -1090,7 +1090,7 @@ function It_w_I0_terms_case3(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) wher
     )
 end
 
-function It_w_I0_terms_case4(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) where {T}
+@inline function It_w_I0_terms_case4(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) where {T}
     a = metric.spin
     r1, _, _, r4 = roots
     _, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
@@ -1146,7 +1146,7 @@ function It_w_I0_terms_case4(metric::Kerr{T}, rs, τ, roots::NTuple{4}, λ) wher
     )# + (logdiv + lineardiv)
 end
 
-function radial_inf_integrals(met::Kerr{T}, roots::NTuple{4}) where {T}
+@inline function radial_inf_integrals(met::Kerr{T}, roots::NTuple{4}) where {T}
     numreals = sum(_isreal2.(roots))
     if numreals == 4
         I1, I2, Ip, Im = Krang.radial_inf_integrals_case2(met, roots)
@@ -1161,7 +1161,7 @@ end
 """
 Returns the radial integrals for the case where there are four real roots in the radial potential, with roots outside the horizon.
 """
-function radial_inf_integrals_case2(metric::Kerr{T}, roots::NTuple{4}) where {T}
+@inline function radial_inf_integrals_case2(metric::Kerr{T}, roots::NTuple{4}) where {T}
     roots = real.(roots)
     _, _, r3, r4 = roots
     _, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
@@ -1210,7 +1210,7 @@ end
 """
 Returns the radial integrals for the case where there are two real roots in the radial potential
 """
-function radial_inf_integrals_case3(metric::Kerr{T}, roots::NTuple{4}) where {T}
+@inline function radial_inf_integrals_case3(metric::Kerr{T}, roots::NTuple{4}) where {T}
     r1, r2, _, _ = roots
     r21, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
 
@@ -1253,7 +1253,7 @@ end
 """
 Returns the radial integrals for the case where there are no real roots in the radial potential
 """
-function radial_inf_integrals_case4(metric::Kerr{T}, roots::NTuple{4}) where {T}
+@inline function radial_inf_integrals_case4(metric::Kerr{T}, roots::NTuple{4}) where {T}
     r1, _, _, r4 = roots
     _, r31, r32, r41, r42, _ = _get_root_diffs(roots...)
     a2 = metric.spin^2
@@ -1306,7 +1306,7 @@ function radial_inf_integrals_case4(metric::Kerr{T}, roots::NTuple{4}) where {T}
     return I1o_m_I0_terms, I2o_m_I0_terms, Ipo_m_I0_terms, Imo_m_I0_terms
 end
 
-function radial_w_I0_terms_integrals(met::Kerr{T}, rs, roots::NTuple{4}, τ, νr) where {T}
+@inline function radial_w_I0_terms_integrals(met::Kerr{T}, rs, roots::NTuple{4}, τ, νr) where {T}
     numreals = sum(_isreal2.(roots))
     if numreals == 4
         I1, I2, Ip, Im =
@@ -1322,7 +1322,7 @@ end
 """
 Returns the radial integrals for the case where there are four real roots in the radial potential, with roots outside the horizon.
 """
-function radial_w_I0_terms_integrals_case2(
+@inline function radial_w_I0_terms_integrals_case2(
     metric::Kerr{T},
     rs,
     roots::NTuple{4},
@@ -1390,7 +1390,7 @@ end
 """
 Returns the radial integrals for the case where there are two real roots in the radial potential
 """
-function radial_w_I0_terms_integrals_case3(
+@inline function radial_w_I0_terms_integrals_case3(
     metric::Kerr{T},
     rs,
     roots::NTuple{4},
@@ -1448,7 +1448,7 @@ end
 """
 Returns the radial integrals for the case where there are no real roots in the radial potential
 """
-function radial_w_I0_terms_integrals_case4(
+@inline function radial_w_I0_terms_integrals_case4(
     metric::Kerr{T},
     rs,
     roots::NTuple{4},
@@ -1584,14 +1584,14 @@ Return the radial integrals
 - `τ` : Mino time
 - `νr` : Sign of radial velocity direction at emission. This is always positive for case 3 and case 4 geodesics.
 """
-function radial_integrals(pix::AbstractPixel, rs, τ, νr)
+@inline function radial_integrals(pix::AbstractPixel, rs, τ, νr)
     met = metric(pix)
     I1_o, I2_o, Ip_o, Im_o = radial_inf_integrals_m_I0_terms(pix)
     I1_s, I2_s, Ip_s, Im_s = radial_w_I0_terms_integrals(met, rs, pix.roots, τ, νr)
     return τ, I1_o - I1_s, I2_o - I2_s, Ip_o - Ip_s, Im_o - Im_s
 end
 
-function _rs_case1_and_2(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
+@inline function _rs_case1_and_2(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
     radial_roots = real.(roots(pix))
     _, _, r3, r4 = radial_roots
     _, r31, r32, r41, r42, _ = _get_root_diffs(radial_roots...)
@@ -1616,7 +1616,7 @@ function _rs_case1_and_2(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} wher
     return (r31 * r4 - r3 * sn) / (r31 - sn), X2 > zero(T), true
 end
 
-function _rs_case3(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
+@inline function _rs_case3(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
     radial_roots = roots(pix)
     r1, r2, _, _ = radial_roots
     r21, r31, r32, r41, r42, _ = _get_root_diffs(radial_roots...)
@@ -1644,7 +1644,7 @@ function _rs_case3(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
     return real(num / den), X3 > zero(T), true
 end
 
-function _rs_case4(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
+@inline function _rs_case4(pix::AbstractPixel, rh, τ::T)::Tuple{T,Bool,Bool} where {T}
     radial_roots = roots(pix)
     r1, _, _, r4 = radial_roots
     root_diffs = _get_root_diffs(radial_roots...)
@@ -1702,7 +1702,7 @@ See [`θ_potential(x)`](@ref) for an implementation of \$\\Theta(\theta)\$.
 - `isindir` : Is the path direct or indirect?
 - `n` : nth image ordered by minotime
 """
-function Gθ(pix::AbstractPixel, θs::T, isindir, n)::Tuple{T,T,T,T,Bool,Bool} where {T}
+@inline function Gθ(pix::AbstractPixel, θs::T, isindir, n)::Tuple{T,T,T,T,Bool,Bool} where {T}
     _, β = screen_coordinate(pix)
     met = metric(pix)
     θo = inclination(pix)
@@ -1819,7 +1819,7 @@ function Gs(pix::AbstractPixel, τ::T) where {T}
     return Δτ
 end
 
-function Gϕ(pix::AbstractPixel, θs::T, isindir, n) where {T}
+@inline function Gϕ(pix::AbstractPixel, θs::T, isindir, n) where {T}
     α, β = screen_coordinate(pix)
     met = metric(pix)
     θo = inclination(pix)
@@ -1882,7 +1882,7 @@ function Gϕ(pix::AbstractPixel, θs::T, isindir, n) where {T}
     return ans, Gs, Go, Ghat, isvortical, true
 end
 
-function Gt(pix::AbstractPixel, θs::T, isindir, n) where {T}
+@inline function Gt(pix::AbstractPixel, θs::T, isindir, n) where {T}
     α, β = screen_coordinate(pix)
     met = metric(pix)
     θo = inclination(pix)
@@ -1951,7 +1951,7 @@ end
 # SlowLightIntensityCachedPixel utility functions
 ##----------------------------------------------------------------------------------------------------------------------
 
-function _absGθo_Gθhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
+@inline function _absGθo_Gθhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
     a = metric.spin
     a2 = a^2
     Go, Ghat, isvortical = zero(T), zero(T), η < zero(T)
@@ -1991,7 +1991,7 @@ function _absGθo_Gθhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
     return Go, Ghat
 end
 
-function _absGϕo_Gϕhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
+@inline function _absGϕo_Gϕhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
 
     a = metric.spin
     Go, Ghat, isvortical = zero(T), zero(T), η < zero(T)
@@ -2031,7 +2031,7 @@ function _absGϕo_Gϕhat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
     return Go, Ghat
 end
 
-function _absGto_Gthat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
+@inline function _absGto_Gthat(metric::Kerr{T}, θo, η, λ)::NTuple{2,T} where {T}
     a = metric.spin
     Go, Ghat, isvortical = zero(T), zero(T), η < zero(T)
 


### PR DESCRIPTION
This helped improve Krang's runtime in the reverse pass by about 10-20%. Essentially, if you return a 
composite object, i.e., struct, tuple, LLVM creates a box which can prevent Enzyme from fully optimizing 
the reverse pass. I've gone through some hot points we identified and added inline where necessary.

I probably missed some, and in the long run, we may want to think about not returning so many tuples. 

