### PR TITLE
Fix _isreal2: classify near-zero complex numbers as real

### DIFF
--- a/src/metrics/Kerr/misc.jl
+++ b/src/metrics/Kerr/misc.jl
@@ -15,13 +15,12 @@ export λ,
 
 
 """
-Checks if a complex number is real to some tolerance
+Checks if a complex number is real to within √eps of its own magnitude
+(or √eps absolute, whichever is larger).
 """
-function _isreal2(num) 
-    ren, imn = reim(num)
-    ren2 = ren^2
-    imn2 = imn^2
-    return Base.:&(1, (imn2 / (imn2 + ren2))  < eps(real(num)))
+function _isreal2(num)
+    T = real(typeof(num))
+    abs2(imag(num)) <= eps(T) * max(abs2(num), one(T))
 end
 
 """

--- a/test/kerr_misc_tests.jl
+++ b/test/kerr_misc_tests.jl
@@ -18,6 +18,16 @@
         (-6.0 + 0im, 0.0 + 0im, 3.0 + 0im, 3.0 + 0im),
     ) ≈ 0.0 atol = 1e-5
 
+    @testset "_isreal2 near-zero roots" begin
+        # Schwarzschild r=0 root: ~3e-15 + 3e-15·i, must classify real.
+        ηv = η(ssmet, 0.0, 50.0, π/3)
+        λv = λ(ssmet, 0.0, π/3)
+        roots = Krang.get_radial_roots(ssmet, ηv, λv)
+        @test sum(Krang._isreal2, roots) == 4
+        pix = Krang.SlowLightIntensityPixel(ssmet, 0.0, 50.0, π/3)
+        @test isfinite(pix.I0_inf)
+    end
+
 
     @testset "Radial Integrals 1" begin
         a = 0.99


### PR DESCRIPTION
The previous relative-tolerance test misclassified roots with both parts at machine precision (e.g. the trivial r=0 root from get_radial_roots, returned as ~3e-15 + 3e-15·i).