### PR TITLE
Make ϕ_kerr_schild and ϕ_BL type-stable and GPU-safe

### DIFF
--- a/ext/KrangMetalExt.jl
+++ b/ext/KrangMetalExt.jl
@@ -2,6 +2,8 @@ module KrangMetalExt
 using Krang
 using Metal
 
+Krang.has_metal() = true
+
 @inline _complex_inv(z::ComplexF32) = conj(z) / abs2(z)
 @inline _complex_cbrt(z::ComplexF32) = abs(z)^(1f0/3) * cis(angle(z) / 3f0)
 

--- a/src/Krang.jl
+++ b/src/Krang.jl
@@ -11,6 +11,9 @@ using Rotations
                                          $(DOCSTRING)
                                          """
 
+# True iff KrangMetalExt is loaded; gate CPU-only code (e.g. `@warn`) so the rest of the function can compile to Metal.
+has_metal(_...) = false
+
 include("metrics/AbstractMetric.jl")
 include("metrics/Kerr/Kerr.jl")
 include("cameras/camera_types.jl")

--- a/src/schemes/RayTrace.jl
+++ b/src/schemes/RayTrace.jl
@@ -155,14 +155,14 @@ function ϕ_kerr_schild(metric::Kerr{T}, rBL, ϕBL) where {T}
     temp = sqrt(1 - a^2)
     rp = 1 + temp
     rm = 1 - temp
-    num = rBL - rp + eps()
-    den = rBL - rm + eps()
+    num = rBL - rp + eps(T)
+    den = rBL - rm + eps(T)
 
     term1 = a / (2temp) * log(abs(num / den))
     term2 = -atan(a, rBL)
     ans = ϕBL + term1 + term2
     if isinf(ans)
-        @warn "ϕ_kerr_schild is inf at rs=$rBL. This usually happens if the ray intersects the horizon."
+        has_metal() || @warn "ϕ_kerr_schild is inf at rs=$rBL. This usually happens if the ray intersects the horizon."
         return ϕBL + term2
     end
     return ans
@@ -173,14 +173,14 @@ function ϕ_BL(metric::Kerr{T}, rKS, ϕKS) where {T}
     temp = sqrt(1 - a^2)
     rp = 1 + temp
     rm = 1 - temp
-    num = rKS - rp + eps()
-    den = rKS - rm + eps()
+    num = rKS - rp + eps(T)
+    den = rKS - rm + eps(T)
 
     term1 = -a / (2temp) * log(abs(num / den))
     term2 = atan(a, rKS)
     ans = ϕKS + term1 + term2
     if isinf(ans)
-        @warn "ϕ_BL is inf at rs=$rKS. This usually happens if the ray intersects the horizon."
+        has_metal() || @warn "ϕ_BL is inf at rs=$rKS. This usually happens if the ray intersects the horizon."
         return ϕKS + term2
     end
     return ans

--- a/test/raytracer_tests.jl
+++ b/test/raytracer_tests.jl
@@ -31,6 +31,11 @@
         @test yrat ≈ 1.0 atol = 1e-5
         @test zrat ≈ 1.0 atol = 1e-5
 
+        # ϕ_kerr_schild / ϕ_BL must return T (not Union{T, Float64}) on Float32.
+        let metf = Krang.Kerr(0.5f0)
+            @test (@inferred Float32 Krang.ϕ_kerr_schild(metf, 5.0f0, 0.0f0)) isa Float32
+            @test (@inferred Float32 Krang.ϕ_BL(metf, 5.0f0, 0.0f0)) isa Float32
+        end
     end
 
     @testset "Level Set" begin


### PR DESCRIPTION
Replace untyped eps() with eps(T) and gate the @warn on has_metal() (overridden by KrangMetalExt) so the same code can compile to Metal.